### PR TITLE
Fix issues in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ Export your personal Spotify data: playlists, saved tracks/albums/shows, etc. as
 * Setting up
 1. The easiest way is =pip3 install --user git+https://github.com/karlicoss/spotifyexport=.
 
-   Alternatively, use =git clone --recursive=, or =git pull && git submodules update --init=. After that, you can use =pip3 install --editable=.
+   Alternatively, use =git clone --recursive=, or =git pull && git submodule update --init=. After that, you can use =pip3 install --editable=.
 2. To use the API, you need to create a new app on [[https://developer.spotify.com/dashboard/applications][Spotify for Developers]]
 
    For =redirect_uri=: you can pick pretty much anything, e.g. =https://github.com=. After that you'll get =client_id= and =client_secret=.

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ Export your personal Spotify data: playlists, saved tracks/albums/shows, etc. as
 * Setting up
 1. The easiest way is =pip3 install --user git+https://github.com/karlicoss/spotifyexport=.
 
-   Alternatively, use =git clone --recursive=, or =git pull && git submodule update --init=. After that, you can use =pip3 install --editable=.
+   Alternatively, use =git clone --recursive=, or =git pull && git submodule update --init=. After that, you can use =pip3 install --editable .=.
 2. To use the API, you need to create a new app on [[https://developer.spotify.com/dashboard/applications][Spotify for Developers]]
 
    For =redirect_uri=: you can pick pretty much anything, e.g. =https://github.com=. After that you'll get =client_id= and =client_secret=.
@@ -42,13 +42,13 @@ Usage:
 
 After that, use:
 
-: python3 -m spotifyexport.export --secrets /path/to/secrets.py
+: python3 -m spotifyexport.export --secrets /path/to/secrets.py > output.json
 
 That way you type less and have control over where you keep your plaintext secrets.
 
 *Alternatively*, you can pass parameters directly, e.g.
 
-: python3 -m spotifyexport.export --client_id <client_id> --client_secret <client_secret> --redirect_uri <redirect_uri> --cache_path <cache_path>
+: python3 -m spotifyexport.export --client_id <client_id> --client_secret <client_secret> --redirect_uri <redirect_uri> --cache_path <cache_path> > output.json
 
 However, this is verbose and prone to leaking your keys/tokens/passwords in shell history.
 


### PR DESCRIPTION
Fixed a couple issues in the readme

* `git submodules` should be `git submodule`
* `pip install --editable` said it required an argument, use current directory
* JSON is output to stdout, so add a redirect to usage
